### PR TITLE
Converting Address to Identity + bash script to build and test

### DIFF
--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -1,0 +1,2 @@
+forc build
+cargo test

--- a/src/main.sw
+++ b/src/main.sw
@@ -30,6 +30,9 @@ abi Token {
     // Set mint amount for each address
     #[storage(read, write)]
     fn set_mint_amount(mint_amount: u64);
+
+    #[storage(read)]
+    fn mint_to_id(amount: u64, address: Identity);
     // Get balance of the contract coins
     fn get_balance() -> u64;
     // Return the mint amount
@@ -106,6 +109,12 @@ impl Token for Contract {
         storage.config = config;
     }
 
+    #[storage(read)]
+    fn mint_to_id(amount: u64, address: Identity){
+        validate_owner();
+        mint_to(amount, address);
+    }
+
     #[storage(read, write)]
     fn set_mint_amount(mint_amount: u64) {
         validate_owner();
@@ -123,6 +132,8 @@ impl Token for Contract {
         validate_owner();
         burn(burn_amount);
     }
+
+    
 
     #[storage(read)]
     fn transfer_coins(coins: u64, address: Identity) {

--- a/src/main.sw
+++ b/src/main.sw
@@ -14,6 +14,7 @@ use std::{
         AuthError,
         msg_sender,
     },
+    identity::{Identity},
     call_frames::{contract_id, msg_asset_id},
     context::{balance_of, msg_amount},
     contract_id::ContractId,
@@ -25,7 +26,7 @@ use std::{
 abi Token {
     // Initialize contract
     #[storage(read, write)]
-    fn initialize(config: TokenInitializeConfig, mint_amount: u64, address: Address);
+    fn initialize(config: TokenInitializeConfig, mint_amount: u64, address: Identity);
     // Set mint amount for each address
     #[storage(read, write)]
     fn set_mint_amount(mint_amount: u64);
@@ -44,10 +45,10 @@ abi Token {
     fn burn_coins(burn_amount: u64);
     // Transfer a contract coins to a given output
     #[storage(read)]
-    fn transfer_coins(coins: u64, address: Address);
+    fn transfer_coins(coins: u64, address: Identity);
     // Transfer a specified token from the contract to a given output
     #[storage(read)]
-    fn transfer_token_to_output(coins: u64, asset_id: ContractId, address: Address);
+    fn transfer_token_to_output(coins: u64, asset_id: ContractId, address: Identity);
     // Method called from address to mint coins
     #[storage(read, write)]
     fn mint();    
@@ -56,7 +57,7 @@ abi Token {
     fn config() -> TokenInitializeConfig;
     // Is user already minted test token
     #[storage(read)]
-    fn already_minted(address: Address) -> bool;
+    fn already_minted(address: Identity) -> bool;
 }
 
 const ZERO_B256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
@@ -74,11 +75,9 @@ storage {
         symbol: "        ",
         decimals: 1u8,
     },
-    owner: Address = Address {
-        value: ZERO_B256,
-    },
+    owner: Identity = Identity::Address(Address::from(ZERO_B256)),
     mint_amount: u64 = 0,
-    mint_list: StorageMap<Address, bool> = StorageMap {},
+    mint_list: StorageMap<Identity, bool> = StorageMap {},
 }
 
 enum Error {
@@ -88,18 +87,10 @@ enum Error {
     NotOwner: (),
 }
 
-pub fn get_msg_sender_address_or_panic() -> Address {
-    let sender: Result<Identity, AuthError> = msg_sender();
-    if let Identity::Address(address) = sender.unwrap() {
-        address
-    } else {
-        revert(0);
-    }
-}
 
 #[storage(read)]
 fn validate_owner() {
-    let sender = get_msg_sender_address_or_panic();
+    let sender = msg_sender().unwrap(); 
     require(storage.owner == sender, Error::NotOwner);
 }
 
@@ -108,8 +99,8 @@ impl Token for Contract {
     // Owner methods
     //////////////////////////////////////
     #[storage(read, write)]
-    fn initialize(config: TokenInitializeConfig, mint_amount: u64, owner: Address) {
-        require(storage.owner.into() == ZERO_B256, Error::CannotReinitialize);
+    fn initialize(config: TokenInitializeConfig, mint_amount: u64, owner: Identity) {
+        require(storage.owner == Identity::Address(Address::from(ZERO_B256)), Error::CannotReinitialize);
         storage.owner = owner;
         storage.mint_amount = mint_amount;
         storage.config = config;
@@ -134,15 +125,15 @@ impl Token for Contract {
     }
 
     #[storage(read)]
-    fn transfer_coins(coins: u64, address: Address) {
+    fn transfer_coins(coins: u64, address: Identity) {
         validate_owner();
-        transfer_to_address(coins, contract_id(), address);
+        transfer(coins, contract_id(), address);
     }
 
     #[storage(read)]
-    fn transfer_token_to_output(coins: u64, asset_id: ContractId, address: Address) {
+    fn transfer_token_to_output(coins: u64, asset_id: ContractId, address: Identity) {
         validate_owner();
-        transfer_to_address(coins, asset_id, address);
+        transfer(coins, asset_id, address);
     }
 
     //////////////////////////////////////
@@ -153,11 +144,11 @@ impl Token for Contract {
         require(storage.mint_amount > 0, Error::MintIsClosed);
 
         // Enable a address to mint only once
-        let sender = get_msg_sender_address_or_panic();
+        let sender = msg_sender().unwrap();
         require(storage.mint_list.get(sender) == false, Error::AddressAlreadyMint);
 
         storage.mint_list.insert(sender, true);
-        mint_to_address(storage.mint_amount, sender);
+        mint_to(storage.mint_amount, sender);
     }
 
     //////////////////////////////////////
@@ -181,7 +172,7 @@ impl Token for Contract {
     }
 
     #[storage(read)]
-    fn already_minted(address: Address) -> bool{
+    fn already_minted(address: Identity) -> bool{
         storage.mint_list.get(address)
     }
 }

--- a/tests/local_tests/deposit_and_transfer_eth.rs
+++ b/tests/local_tests/deposit_and_transfer_eth.rs
@@ -23,7 +23,7 @@ async fn deposit_and_transfer_eth() {
         "BBC",
         9,
         token_mint_amount,
-        Address::from(wallets.wallet_owner.address()),
+        Identity::Address(Address::from(wallets.wallet_owner.address())),
     )
     .await
     .unwrap();
@@ -79,7 +79,7 @@ async fn deposit_and_transfer_eth() {
         .transfer_token_to_output(
             send_native_token_amount,
             ContractId::from(*BASE_ASSET_ID),
-            Address::from(wallets.wallet_owner.address()),
+            Identity::Address(Address::from(wallets.wallet_owner.address())),
         )
         .append_variable_outputs(1)
         .call()

--- a/tests/local_tests/mint_and_transfer.rs
+++ b/tests/local_tests/mint_and_transfer.rs
@@ -33,7 +33,7 @@ async fn mint_and_transfer() {
         "BBC",
         9,
         token_mint_amount,
-        Address::from(wallets.wallet_owner.address()),
+        Identity::Address(Address::from(wallets.wallet_owner.address())),
     )
     .await
     .unwrap();

--- a/tests/local_tests/only_owner_can_call.rs
+++ b/tests/local_tests/only_owner_can_call.rs
@@ -1,4 +1,3 @@
-
 use fuels::prelude::*;
 
 use crate::utils::local_tests_utils::abi_calls::*;
@@ -29,7 +28,7 @@ async fn only_owner_can_call() {
         "BBC",
         9,
         token_mint_amount,
-        Address::from(wallets.wallet_owner.address()),
+        Identity::Address(Address::from(wallets.wallet_owner.address())),
     )
     .await
     .unwrap();
@@ -63,7 +62,7 @@ async fn only_owner_can_call() {
         &wallet1_token_instance,
         1,
         ContractId::from(*owner_token_istance.get_contract_id().hash()),
-        Address::from(wallets.wallet2.address()),
+        Identity::Address(Address::from(wallets.wallet2.address())),
     )
     .await
     .is_err();

--- a/tests/local_tests/token_contract.rs
+++ b/tests/local_tests/token_contract.rs
@@ -1,4 +1,7 @@
-use crate::utils::{local_tests_utils::{abi_calls::*, setup_utils::setup}, number_utils::*};
+use crate::utils::{
+    local_tests_utils::{abi_calls::*, setup_utils::setup},
+    number_utils::*,
+};
 use fuels::prelude::*;
 
 #[tokio::test]
@@ -30,7 +33,7 @@ async fn token_contract() {
         "BBC",
         9,
         token_mint_amount,
-        Address::from(wallets.wallet_owner.address()),
+        Identity::Address(Address::from(wallets.wallet_owner.address())),
     )
     .await
     .unwrap();
@@ -52,7 +55,7 @@ async fn token_contract() {
         "BBC",
         9,
         token_mint_amount,
-        Address::from(wallets.wallet_owner.address()),
+        Identity::Address(Address::from(wallets.wallet_owner.address())),
     )
     .await
     .is_err();
@@ -102,7 +105,7 @@ async fn token_contract() {
     );
 
     // Transfer tokens to the wallet
-    let address = Address::from(wallets.wallet_owner.address());
+    let address = Identity::Address(Address::from(wallets.wallet_owner.address()));
     transfer_coins(&owner_token_istance, wallet_token_amount, address.clone())
         .await
         .unwrap();

--- a/tests/testnet_tests/deploy.rs
+++ b/tests/testnet_tests/deploy.rs
@@ -114,7 +114,11 @@ async fn deploy_token_contract(mut deploy_config: DeployConfig) {
         decimals: deploy_config.decimals,
     };
     let _res = methods
-        .initialize(config, mint_amount, Address::from(wallet.address()))
+        .initialize(
+            config,
+            mint_amount,
+            Identity::Address(Address::from(wallet.address())),
+        )
         .tx_params(TxParameters::new(Some(1), Some(1000000), None))
         .call()
         .await;

--- a/tests/testnet_tests/initialize.rs
+++ b/tests/testnet_tests/initialize.rs
@@ -24,7 +24,7 @@ async fn initialize() {
                 decimals: DECIMALS,
             },
             parse_units(1000, DECIMALS),
-            Address::from(wallet.address()),
+            Identity::Address(Address::from(wallet.address())),
         )
         .tx_params(TxParameters::new(Some(1), Some(1000000), None))
         .call()

--- a/tests/utils/local_tests_utils.rs
+++ b/tests/utils/local_tests_utils.rs
@@ -19,7 +19,7 @@ pub mod abi_calls {
         symbol: &str,
         decimals: u8,
         mint_amount: u64,
-        address: Address,
+        address: Identity,
     ) -> Result<CallResponse<()>, Error> {
         let mut name = name.to_string();
         let mut symbol = symbol.to_string();
@@ -79,7 +79,7 @@ pub mod abi_calls {
         contract: &TestToken,
         coins: u64,
         asset_id: ContractId,
-        address: Address,
+        address: Identity,
     ) -> Result<CallResponse<()>, Error> {
         contract
             .methods()
@@ -91,7 +91,7 @@ pub mod abi_calls {
     pub async fn transfer_coins(
         contract: &TestToken,
         coins: u64,
-        address: Address,
+        address: Identity,
     ) -> Result<CallResponse<()>, Error> {
         contract
             .methods()


### PR DESCRIPTION
- Converting all Addresses to Identity 
- Adding bash script to build and test instead of doing each command separately 

You don't want to limit minting, owning, and transferring to only human addresses, Identity is a superset of Wallets/Humans/Bots + Smart Contracts